### PR TITLE
Call out Uchiwa is not yet supported

### DIFF
--- a/02-installation.md
+++ b/02-installation.md
@@ -82,7 +82,7 @@ sudo /etc/init.d/sensu-backend start
 sudo /etc/init.d/sensu-agent start
 ```
 
-#### Ubuntu 16.04 / CentOS 7 / RHEL 7
+#### Ubuntu 16.04 / Debian Stretch / CentOS 7 / RHEL 7
 
 Start the services using systemd.
 

--- a/02-installation.md
+++ b/02-installation.md
@@ -82,7 +82,7 @@ sudo /etc/init.d/sensu-backend start
 sudo /etc/init.d/sensu-agent start
 ```
 
-#### Ubuntu 16.04 / Debian Stretch / CentOS 7 / RHEL 7
+#### Ubuntu 16.04 / CentOS 7 / RHEL 7
 
 Start the services using systemd.
 

--- a/02-installation.md
+++ b/02-installation.md
@@ -108,6 +108,10 @@ The backend requires 3 exposed ports and persistent storage. This example uses a
 
 We suggest, but do not require, persistent storage for sensu-agents. The Sensu Agent will cache runtime assets locally for each check (see [Checks and Assets](06-checks-and-assets.md) for more details). This storage should be unique per sensu-agent process.
 
+### Dashboards and Visualizations
+
+Currently Uchiwa is not yet supported but it is under active development, with a release currently planned for late 2018.
+
 ### How To
 
 1. Start the sensu-backend process

--- a/02-installation.md
+++ b/02-installation.md
@@ -110,7 +110,7 @@ We suggest, but do not require, persistent storage for sensu-agents. The Sensu A
 
 ### Dashboards and Visualizations
 
-Currently Uchiwa is not yet supported but it is under active development.
+Currently Uchiwa is not yet supported, but a new dashboard is under active development.
 
 ### How To
 

--- a/02-installation.md
+++ b/02-installation.md
@@ -110,7 +110,7 @@ We suggest, but do not require, persistent storage for sensu-agents. The Sensu A
 
 ### Dashboards and Visualizations
 
-Currently Uchiwa is not yet supported but it is under active development, with a release currently planned for late 2018.
+Currently Uchiwa is not yet supported but it is under active development.
 
 ### How To
 

--- a/11-visualizations.md
+++ b/11-visualizations.md
@@ -1,0 +1,5 @@
+# Visualizations
+
+## Uchiwa
+
+Currently Uchiwa is not supported but it is under active development with a release currently planned for late 2018.

--- a/11-visualizations.md
+++ b/11-visualizations.md
@@ -2,4 +2,4 @@
 
 ## Uchiwa
 
-Currently Uchiwa is not supported but it is under active development.
+Currently Uchiwa is not supported, but a new dashboard is under active development.

--- a/11-visualizations.md
+++ b/11-visualizations.md
@@ -2,4 +2,4 @@
 
 ## Uchiwa
 
-Currently Uchiwa is not supported but it is under active development with a release currently planned for late 2018.
+Currently Uchiwa is not supported but it is under active development.


### PR DESCRIPTION
Create visualizations page to contains details on various visualization products and call out in the install directory that Uchiwa is not yet supported.